### PR TITLE
Inject config via secrets

### DIFF
--- a/cloudlift/deployment/deployer.py
+++ b/cloudlift/deployment/deployer.py
@@ -31,9 +31,13 @@ def deploy_new_version(client, cluster_name, ecs_service_name,
         )
     else:
         task_definition.set_images(deploy_version_tag)
+
+    task_definition.set_execution_role_arn(account_id)
+
     for container in task_definition.containers:
         task_definition.apply_container_environment(
-            container, region, account_id, service_name, env_config)
+            container, region, account_id, env_name, service_name, env_config)
+
     print_task_diff(ecs_service_name, task_definition.diff, color)
     new_task_definition = deployment.update_task_definition(task_definition)
     response = deploy_and_wait(deployment, new_task_definition, color)

--- a/cloudlift/deployment/deployer.py
+++ b/cloudlift/deployment/deployer.py
@@ -32,8 +32,6 @@ def deploy_new_version(client, cluster_name, ecs_service_name,
     else:
         task_definition.set_images(deploy_version_tag)
 
-    task_definition.set_execution_role_arn(account_id)
-
     for container in task_definition.containers:
         task_definition.apply_container_environment(
             container, region, account_id, env_name, service_name, env_config)

--- a/cloudlift/deployment/deployer.py
+++ b/cloudlift/deployment/deployer.py
@@ -12,7 +12,7 @@ from cloudlift.config.logging import log_bold, log_err, log_intent, log_with_col
 
 def deploy_new_version(client, cluster_name, ecs_service_name,
                        deploy_version_tag, service_name, sample_env_file_path,
-                       env_name, color='white', complete_image_uri=None):
+                       env_name, region, account_id, color='white', complete_image_uri=None):
     env_config = build_config(env_name, service_name, sample_env_file_path)
     deployment = DeployAction(client, cluster_name, ecs_service_name)
     if deployment.service.desired_count == 0:
@@ -32,7 +32,8 @@ def deploy_new_version(client, cluster_name, ecs_service_name,
     else:
         task_definition.set_images(deploy_version_tag)
     for container in task_definition.containers:
-        task_definition.apply_container_environment(container, env_config)
+        task_definition.apply_container_environment(
+            container, region, account_id, service_name, env_config)
     print_task_diff(ecs_service_name, task_definition.diff, color)
     new_task_definition = deployment.update_task_definition(task_definition)
     response = deploy_and_wait(deployment, new_task_definition, color)

--- a/cloudlift/deployment/ecs.py
+++ b/cloudlift/deployment/ecs.py
@@ -325,10 +325,6 @@ class EcsTaskDefinition(dict):
             self[u'taskRoleArn'] = role_arn
             self._diff.append(diff)
 
-    def set_execution_role_arn(self, account_id):
-        self[u'executionRoleArn'] = 'arn:aws:iam::{}:role/ecsTaskExecutionRole'.format(account_id)
-
-
 class EcsTaskDefinitionDiff(object):
     def __init__(self, container, field, value, old_value):
         self.container = container

--- a/cloudlift/deployment/ecs.py
+++ b/cloudlift/deployment/ecs.py
@@ -283,7 +283,7 @@ class EcsTaskDefinition(dict):
                 self._diff.append(diff)
                 container[u'command'] = [new_command]
 
-    def apply_container_environment(self, container, new_environment):
+    def apply_container_environment(self, container, region, account_id, service_name, new_environment):
         old_environment = {
             env['name']: env['value'] for env in container.get(
                 'environment',
@@ -300,10 +300,11 @@ class EcsTaskDefinition(dict):
         )
         self._diff.append(diff)
 
-        container[u'environment'] = [
+        container[u'environment'] = []
+        container[u'secrets'] = [
             {
                 "name": e,
-                "value": merged_environment[e]
+                "valueFrom": 'arn:aws:ssm:{}:{}:{}/{}'.format(region, account_id, service_name, e)
             } for e in merged_environment
         ]
 

--- a/cloudlift/deployment/ecs.py
+++ b/cloudlift/deployment/ecs.py
@@ -284,8 +284,10 @@ class EcsTaskDefinition(dict):
                 container[u'command'] = [new_command]
 
     def apply_container_environment(self, container, region, account_id, service_name, new_secrets):
-        old_keys = {data['name']: '' for data in container.get('secrets', {})}
-        new_keys = {data[0]: '****' for data in new_secrets}
+        masked_password = '****'
+        old_keys = {
+            data['name']: masked_password for data in container.get('secrets', {})}
+        new_keys = {data[0]: masked_password for data in new_secrets}
 
         self._diff.append(EcsTaskDefinitionDiff(
             container[u'name'],

--- a/cloudlift/deployment/ecs.py
+++ b/cloudlift/deployment/ecs.py
@@ -283,21 +283,6 @@ class EcsTaskDefinition(dict):
                 self._diff.append(diff)
                 container[u'command'] = [new_command]
 
-    def set_environment(self, environment_list):
-        environment = {}
-
-        for env in environment_list:
-            environment.setdefault(env[0], {})
-            environment[env[0]][env[1]] = env[2]
-
-        self.validate_container_options(**environment)
-        for container in self.containers:
-            if container[u'name'] in environment:
-                self.apply_container_environment(
-                    container=container,
-                    new_environment=environment[container[u'name']]
-                )
-
     def apply_container_environment(self, container, new_environment):
         old_environment = {
             env['name']: env['value'] for env in container.get(

--- a/cloudlift/deployment/service_updater.py
+++ b/cloudlift/deployment/service_updater.py
@@ -63,6 +63,8 @@ class ServiceUpdater(object):
                     self.name,
                     self.env_sample_file,
                     self.environment,
+                    self.region,
+                    self.account_id,
                     color,
                     image_url
                 )

--- a/test/deployment/test_deployer.py
+++ b/test/deployment/test_deployer.py
@@ -10,7 +10,7 @@ class TestDeployNewVersion(unittest.TestCase):
     @patch('cloudlift.deployment.deployer.ParameterStore')
     @patch('cloudlift.deployment.deployer.DeployAction')
     def test(self, DeployAction, ParameterStore):
-        sample_env_file_content = "key1=value1\nkey2=value2"
+        sample_env_file_content = "unmodified-key=value1\nadded-key=value2"
         client = MagicMock()
 
         mock_deployment = MagicMock()
@@ -19,7 +19,7 @@ class TestDeployNewVersion(unittest.TestCase):
         mock_param_store = MagicMock()
         ParameterStore.return_value = mock_param_store
         mock_param_store.get_existing_config.return_value = {
-            'key1': 'valu1', 'key2': 'value2'}
+            'unmodified-key': 'value1', 'added-key': 'value2'}
 
         task_definition = EcsTaskDefinition({
             'containerDefinitions': [
@@ -27,8 +27,9 @@ class TestDeployNewVersion(unittest.TestCase):
                     'name': 'test-service',
                     'image': 'test-service:sha0',
                     'secrets': [
-                        {'name': 'existing-key',
-                            'valueFrom': 'arn:aws:ssm:region-a:1234:test-service/existing-key'},
+                        {'name': 'deleted-key',
+                            'valueFrom': 'arn:aws:ssm:region-a:1234:test-service/deleted-key'},
+                        {'name': 'unmodified-key', 'valueFrom': 'arn:aws:ssm:region-a:1234:test-service/unmodified-key'},
                     ],
                 }
             ]
@@ -41,9 +42,9 @@ class TestDeployNewVersion(unittest.TestCase):
                     'image': 'test-service:sha1',
                     'environment': [],
                     'secrets': [
-                        {'name': 'key1', 'valueFrom': 'arn:aws:ssm:region-a:1234:test-service/key1'},
-                        {'name': 'key2',
-                            'valueFrom': 'arn:aws:ssm:region-a:1234:test-service/key2'}
+                        {'name': 'unmodified-key', 'valueFrom': 'arn:aws:ssm:region-a:1234:test-service/unmodified-key'},
+                        {'name': 'added-key',
+                            'valueFrom': 'arn:aws:ssm:region-a:1234:test-service/added-key'}
                     ],
                 }
             ]

--- a/test/deployment/test_deployer.py
+++ b/test/deployment/test_deployer.py
@@ -1,0 +1,73 @@
+import unittest
+import json
+from unittest.mock import MagicMock
+from unittest.mock import patch, mock_open
+
+from cloudlift.deployment import deploy_new_version, EcsTaskDefinition
+
+
+class TestDeployNewVersion(unittest.TestCase):
+    @patch('cloudlift.deployment.deployer.ParameterStore')
+    @patch('cloudlift.deployment.deployer.DeployAction')
+    def test(self, DeployAction, ParameterStore):
+        sample_env_file_content = "key1=value1\nkey2=value2"
+        client = MagicMock()
+
+        mock_deployment = MagicMock()
+        DeployAction.return_value = mock_deployment
+
+        mock_param_store = MagicMock()
+        ParameterStore.return_value = mock_param_store
+        mock_param_store.get_existing_config.return_value = {
+            'key1': 'valu1', 'key2': 'value2'}
+
+        task_definition = EcsTaskDefinition({
+            'containerDefinitions': [
+                {
+                    'name': 'test-service',
+                    'image': 'test-service:sha0'
+                }
+            ]
+        })
+
+        expected_task_definition = EcsTaskDefinition({
+            'containerDefinitions': [
+                {
+                    'name': 'test-service',
+                    'image': 'test-service:sha1',
+                    'environment': [],
+                    'secrets': [
+                        {'name': 'key1', 'valueFrom': 'arn:aws:ssm:region-a:1234:test-service/key1'},
+                        {'name': 'key2',
+                            'valueFrom': 'arn:aws:ssm:region-a:1234:test-service/key2'}
+                    ],
+                }
+            ]
+        })
+
+        mock_deployment.get_current_task_definition.return_value = task_definition
+        mock_deployment.get_service.return_value = MagicMock(errors=[])
+
+        with patch("builtins.open", mock_open(read_data=sample_env_file_content)):
+            try:
+                deploy_new_version(
+                    client,
+                    cluster_name="test-cluster",
+                    ecs_service_name="test-service-ecs",
+                    deploy_version_tag="sha1",
+                    service_name="test-service",
+                    sample_env_file_path='/tmp/filepath',
+                    env_name='test',
+                    region="region-a",
+                    account_id='1234',
+                )
+            except:
+                self.fail('exception raised when not expected')
+
+        DeployAction.assert_called_with(
+            client, 'test-cluster', 'test-service-ecs')
+
+        assert task_definition == expected_task_definition
+
+        mock_deployment.update_task_definition.assert_called_with(
+            expected_task_definition)

--- a/test/deployment/test_deployer.py
+++ b/test/deployment/test_deployer.py
@@ -26,25 +26,29 @@ class TestDeployNewVersion(unittest.TestCase):
                 {
                     'name': 'test-service',
                     'image': 'test-service:sha0',
+                    'environment': [
+                        { 'name': 'key1', 'value': 'value1' }
+                    ],
                     'secrets': [
                         {'name': 'deleted-key',
-                            'valueFrom': 'arn:aws:ssm:region-a:1234:test-service/deleted-key'},
-                        {'name': 'unmodified-key', 'valueFrom': 'arn:aws:ssm:region-a:1234:test-service/unmodified-key'},
+                            'valueFrom': 'arn:aws:ssm:region-a:1234:parameter/test/test-service/deleted-key'},
+                        {'name': 'unmodified-key', 'valueFrom': 'arn:aws:ssm:region-a:1234:parameter/test/test-service/unmodified-key'},
                     ],
                 }
             ]
         })
 
         expected_task_definition = EcsTaskDefinition({
+            'executionRoleArn': 'arn:aws:iam::1234:role/ecsTaskExecutionRole',
             'containerDefinitions': [
                 {
                     'name': 'test-service',
                     'image': 'test-service:sha1',
                     'environment': [],
                     'secrets': [
-                        {'name': 'unmodified-key', 'valueFrom': 'arn:aws:ssm:region-a:1234:test-service/unmodified-key'},
+                        {'name': 'unmodified-key', 'valueFrom': 'arn:aws:ssm:region-a:1234:parameter/test/test-service/unmodified-key'},
                         {'name': 'added-key',
-                            'valueFrom': 'arn:aws:ssm:region-a:1234:test-service/added-key'}
+                            'valueFrom': 'arn:aws:ssm:region-a:1234:parameter/test/test-service/added-key'}
                     ],
                 }
             ]

--- a/test/deployment/test_deployer.py
+++ b/test/deployment/test_deployer.py
@@ -25,7 +25,11 @@ class TestDeployNewVersion(unittest.TestCase):
             'containerDefinitions': [
                 {
                     'name': 'test-service',
-                    'image': 'test-service:sha0'
+                    'image': 'test-service:sha0',
+                    'secrets': [
+                        {'name': 'existing-key',
+                            'valueFrom': 'arn:aws:ssm:region-a:1234:test-service/existing-key'},
+                    ],
                 }
             ]
         })

--- a/test/deployment/test_deployer.py
+++ b/test/deployment/test_deployer.py
@@ -22,6 +22,7 @@ class TestDeployNewVersion(unittest.TestCase):
             'unmodified-key': 'value1', 'added-key': 'value2'}
 
         task_definition = EcsTaskDefinition({
+            'executionRoleArn': 'arn:aws:iam::1234:role/test-service-executionRole',
             'containerDefinitions': [
                 {
                     'name': 'test-service',
@@ -39,7 +40,7 @@ class TestDeployNewVersion(unittest.TestCase):
         })
 
         expected_task_definition = EcsTaskDefinition({
-            'executionRoleArn': 'arn:aws:iam::1234:role/ecsTaskExecutionRole',
+            'executionRoleArn': 'arn:aws:iam::1234:role/test-service-executionRole',
             'containerDefinitions': [
                 {
                     'name': 'test-service',

--- a/test/deployment/test_ecs.py
+++ b/test/deployment/test_ecs.py
@@ -15,6 +15,10 @@ class TestEcsTaskDefinition(unittest.TestCase):
                 'environment': [
                     {'name': 'username', 'value': 'oldUser'},
                 ],
+                'secrets': [
+                    {'name': 'existing-key',
+                        'valueFrom': 'arn:aws:ssm:region-1:1234:test-service/existing-key'},
+                ]
             }
         ]})
 

--- a/test/deployment/test_ecs.py
+++ b/test/deployment/test_ecs.py
@@ -1,0 +1,34 @@
+import unittest
+
+from cloudlift.deployment import EcsTaskDefinition
+
+class TestEcsTaskDefinition(unittest.TestCase):
+    def test_apply_container_environment(self):
+        td = EcsTaskDefinition({ 'containerDefinitions': [
+            {
+                'name': 'hello-world',
+                'environment': [
+                    { 'name': 'username', 'value': 'oldUser' },
+                ],
+            }
+        ]})
+
+        container = td.containers[0]
+
+        # Method call with a side-effect and no return-value.
+        # Assertion has to be done on the side-effect
+        td.apply_container_environment(container, [
+            ('username', 'adminUser'), ('password', 'superSeretPassword'),
+        ])
+
+        expected_task_definition = EcsTaskDefinition({ 'containerDefinitions': [
+            {
+                'name': 'hello-world',
+                'environment': [
+                    { 'name': 'username', 'value': 'adminUser' },
+                    { 'name': 'password', 'value': 'superSeretPassword' },
+                ],
+            }
+        ]})
+
+        self.assertEqual(td, expected_task_definition)

--- a/test/deployment/test_ecs.py
+++ b/test/deployment/test_ecs.py
@@ -8,6 +8,7 @@ class TestEcsTaskDefinition(unittest.TestCase):
         region = 'region-1'
         account_id = '1234'
         service_name = 'test-service'
+        environment = 'test'
 
         td = EcsTaskDefinition({'containerDefinitions': [
             {
@@ -26,19 +27,20 @@ class TestEcsTaskDefinition(unittest.TestCase):
 
         # Method call with a side-effect and no return-value.
         # Assertion has to be done on the side-effect
-        td.apply_container_environment(container, region, account_id, service_name, [
+        td.apply_container_environment(container, region, account_id, environment, service_name, [
             ('username', 'adminUser'), ('password', 'superSeretPassword'),
         ])
 
-        expected_task_definition = EcsTaskDefinition({'containerDefinitions': [
+        expected_task_definition = EcsTaskDefinition({
+            'containerDefinitions': [
             {
                 'name': 'hello-world',
                 'environment': [],
                 'secrets': [
                     {'name': 'username',
-                        'valueFrom': 'arn:aws:ssm:region-1:1234:test-service/username'},
+                        'valueFrom': 'arn:aws:ssm:region-1:1234:parameter/test/test-service/username'},
                     {'name': 'password',
-                        'valueFrom': 'arn:aws:ssm:region-1:1234:test-service/password'},
+                        'valueFrom': 'arn:aws:ssm:region-1:1234:parameter/test/test-service/password'},
                 ],
             }
         ]})

--- a/test/deployment/test_ecs.py
+++ b/test/deployment/test_ecs.py
@@ -2,13 +2,18 @@ import unittest
 
 from cloudlift.deployment import EcsTaskDefinition
 
+
 class TestEcsTaskDefinition(unittest.TestCase):
     def test_apply_container_environment(self):
-        td = EcsTaskDefinition({ 'containerDefinitions': [
+        region = 'region-1'
+        account_id = '1234'
+        service_name = 'test-service'
+
+        td = EcsTaskDefinition({'containerDefinitions': [
             {
                 'name': 'hello-world',
                 'environment': [
-                    { 'name': 'username', 'value': 'oldUser' },
+                    {'name': 'username', 'value': 'oldUser'},
                 ],
             }
         ]})
@@ -17,18 +22,21 @@ class TestEcsTaskDefinition(unittest.TestCase):
 
         # Method call with a side-effect and no return-value.
         # Assertion has to be done on the side-effect
-        td.apply_container_environment(container, [
+        td.apply_container_environment(container, region, account_id, service_name, [
             ('username', 'adminUser'), ('password', 'superSeretPassword'),
         ])
 
-        expected_task_definition = EcsTaskDefinition({ 'containerDefinitions': [
+        expected_task_definition = EcsTaskDefinition({'containerDefinitions': [
             {
                 'name': 'hello-world',
-                'environment': [
-                    { 'name': 'username', 'value': 'adminUser' },
-                    { 'name': 'password', 'value': 'superSeretPassword' },
+                'environment': [],
+                'secrets': [
+                    {'name': 'username',
+                        'valueFrom': 'arn:aws:ssm:region-1:1234:test-service/username'},
+                    {'name': 'password',
+                        'valueFrom': 'arn:aws:ssm:region-1:1234:test-service/password'},
                 ],
             }
         ]})
 
-        self.assertEqual(td, expected_task_definition)
+        assert td == expected_task_definition


### PR DESCRIPTION
## Objective:

Inject configurations from parameter store via `secrets.valueFrom` specification instead of `environment` for security reasons.

## Changes

- Changes to `containerDefinition`
- Create a role for the task definition execution with permissions to read from parameter store for that specific service.
- Changes to how diff is showed during deploy_service. Just displaying what is added and deleted (as we do not have the previous value)
- Clear any prior environment variables set.