### PR TITLE
Add ability to disable ALB and apply large cloud formation templates

### DIFF
--- a/cloudlift/config/service_configuration.py
+++ b/cloudlift/config/service_configuration.py
@@ -151,6 +151,9 @@ class ServiceConfiguration(object):
                         "internal": {
                             "type": "boolean"
                         },
+                        "alb_enabled": {
+                            "type": "boolean",
+                        },
                         "restrict_access_to": {
                             "type": "array",
                             "items": {
@@ -168,7 +171,8 @@ class ServiceConfiguration(object):
                     "required": [
                         "internal",
                         "restrict_access_to",
-                        "container_port"
+                        "container_port",
+                        "alb_enabled"
                     ]
                 },
                 "memory_reservation": {
@@ -267,6 +271,7 @@ class ServiceConfiguration(object):
                 pascalcase(self.service_name): {
                     u'http_interface': {
                         u'internal': False,
+                        u'alb_enabled': True,
                         u'restrict_access_to': [u'0.0.0.0/0'],
                         u'container_port': 80,
                         u'health_check_path': u'/elb-check'

--- a/cloudlift/deployment/changesets.py
+++ b/cloudlift/deployment/changesets.py
@@ -5,6 +5,7 @@ from time import sleep
 import click
 
 from cloudlift.config.logging import log, log_bold, log_err
+from cloudlift.deployment.cloud_formation_stack import prepare_stack_options_for_template
 
 
 def create_change_set(client, service_template_body, stack_name,
@@ -17,13 +18,14 @@ def create_change_set(client, service_template_body, stack_name,
             'ParameterKey': 'KeyPair',
             'ParameterValue': key_name
         })
+    options = prepare_stack_options_for_template(service_template_body, environment, stack_name)
     create_change_set_res = client.create_change_set(
         StackName=stack_name,
         ChangeSetName="cg"+uuid.uuid4().hex,
-        TemplateBody=service_template_body,
         Parameters=change_set_parameters,
         Capabilities=['CAPABILITY_NAMED_IAM'],
-        ChangeSetType='UPDATE'
+        ChangeSetType='UPDATE',
+        **options,
     )
     log("Changeset creation initiated. Checking the progress...")
     change_set = client.describe_change_set(

--- a/cloudlift/deployment/cloud_formation_stack.py
+++ b/cloudlift/deployment/cloud_formation_stack.py
@@ -1,0 +1,48 @@
+from cloudlift.config.region import (get_resource_for,
+                                     get_service_templates_bucket_for_environment,
+                                     get_region_for_environment)
+
+from tempfile import NamedTemporaryFile
+from cloudlift.config.logging import log_intent
+
+TEMPLATE_BODY_LIMIT = 51200
+
+
+def prepare_stack_options_for_template(template_body, environment, stack_name):
+    options = {}
+    if len(template_body) <= TEMPLATE_BODY_LIMIT:
+        options['TemplateBody'] = template_body
+    else:
+        s3 = get_resource_for('s3', environment)
+        bucket_name = get_service_templates_bucket_for_environment(environment)
+
+        if not bucket_name:
+            from cloudlift.exceptions import UnrecoverableException
+            raise UnrecoverableException(
+                'Configure "service_templates_bucket" in environment configuration to apply changes')
+
+        bucket = s3.Bucket(bucket_name)
+        region = get_region_for_environment(environment)
+
+        if bucket not in s3.buckets.all():
+            bucket.create(
+                ACL='private',
+                Bucket=bucket_name,
+                CreateBucketConfiguration={
+                    'LocationConstraint': region,
+                }
+            )
+            s3.BucketVersioning(bucket_name).enable()
+
+        with NamedTemporaryFile() as f:
+            f.write(template_body.encode())
+            path = '{}/{}.template'.format(environment, stack_name)
+            bucket.upload_file(f.name, path)
+
+            template_url = 'https://s3-{}.amazonaws.com/{}/{}'.format(region, bucket_name, path)
+
+            log_intent('Using S3 URL from deploying stack: {}'.format(template_url))
+
+            options['TemplateURL'] = template_url
+
+    return options

--- a/cloudlift/deployment/environment_creator.py
+++ b/cloudlift/deployment/environment_creator.py
@@ -11,6 +11,7 @@ from cloudlift.deployment.changesets import create_change_set
 from cloudlift.deployment.cluster_template_generator import ClusterTemplateGenerator
 from cloudlift.config.logging import log, log_bold, log_err
 from cloudlift.deployment.progress import get_stack_events, print_new_events
+from cloudlift.deployment.cloud_formation_stack import prepare_stack_options_for_template
 
 
 class EnvironmentCreator(object):
@@ -49,9 +50,10 @@ class EnvironmentCreator(object):
                 self.client,
                 self.cluster_name
             )
+            options = prepare_stack_options_for_template(
+                environment_stack_template_body, self.environment, self.cluster_name)
             environment_stack = self.client.create_stack(
                 StackName=self.cluster_name,
-                TemplateBody=environment_stack_template_body,
                 Parameters=[
                     {
                         'ParameterKey': 'KeyPair',
@@ -64,10 +66,11 @@ class EnvironmentCreator(object):
                 ],
                 OnFailure='DO_NOTHING',
                 Capabilities=['CAPABILITY_NAMED_IAM'],
+                **options,
             )
             log_bold("Submitted to cloudformation. Checking progress...")
             self.__print_progress()
-            log_bold(self.cluster_name+" stack created. ID: " +
+            log_bold(self.cluster_name + " stack created. ID: " +
                      environment_stack['StackId'])
 
     def run_update(self, update_ecs_agents):

--- a/cloudlift/deployment/service_creator.py
+++ b/cloudlift/deployment/service_creator.py
@@ -15,6 +15,7 @@ from cloudlift.deployment.changesets import create_change_set
 from cloudlift.config.logging import log, log_bold, log_err
 from cloudlift.deployment.progress import get_stack_events, print_new_events
 from cloudlift.deployment.service_template_generator import ServiceTemplateGenerator
+from cloudlift.deployment.cloud_formation_stack import prepare_stack_options_for_template
 
 
 class ServiceCreator(object):
@@ -50,15 +51,17 @@ class ServiceCreator(object):
         service_template_body = template_generator.generate_service()
 
         try:
+            options = prepare_stack_options_for_template(
+                service_template_body, self.environment, self.stack_name)
             self.client.create_stack(
                 StackName=self.stack_name,
-                TemplateBody=service_template_body,
                 Parameters=[{
                     'ParameterKey': 'Environment',
                     'ParameterValue': self.environment,
                 }],
                 OnFailure='DO_NOTHING',
                 Capabilities=['CAPABILITY_NAMED_IAM'],
+                **options,
             )
             log_bold("Submitted to cloudformation. Checking progress...")
             self._print_progress()

--- a/cloudlift/version/__init__.py
+++ b/cloudlift/version/__init__.py
@@ -1,1 +1,1 @@
-VERSION = '1.6.1'
+VERSION = '1.7.0'

--- a/test/config/service_configuration_test.py
+++ b/test/config/service_configuration_test.py
@@ -57,7 +57,8 @@ class TestServiceConfiguration(object):
                             "http_interface": {
                                 "internal": True,
                                 "container_port": 80,
-                                "restrict_access_to": ["0.0.0.0/0"]
+                                "restrict_access_to": ["0.0.0.0/0"],
+                                "alb_enabled": True,
                             }
                         }
                     }
@@ -87,7 +88,8 @@ class TestServiceConfiguration(object):
                             "http_interface": {
                                 "internal": True,
                                 "container_port": 80,
-                                "restrict_access_to": [u'0.0.0.0/0']
+                                "restrict_access_to": [u'0.0.0.0/0'],
+                                "alb_enabled": True,
                             }
                         }
                     }
@@ -112,7 +114,8 @@ class TestServiceConfiguration(object):
                             "http_interface": {
                                 "internal": True,
                                 "container_port": 80,
-                                "restrict_access_to": [u"123.123.123.123/32"]
+                                "restrict_access_to": [u"123.123.123.123/32"],
+                                "alb_enabled": True,
                             }
                         }
                     }
@@ -138,7 +141,8 @@ class TestServiceConfiguration(object):
                             "http_interface": {
                                 "internal": True,
                                 "container_port": 80,
-                                "restrict_access_to": [u'0.0.0.0/0']
+                                "restrict_access_to": [u'0.0.0.0/0'],
+                                "alb_enabled": True,
                             },
                             "stop_timeout": 120
                         }
@@ -190,7 +194,6 @@ class TestServiceConfigurationValidation(TestCase):
         except UnrecoverableException as e:
             self.assertTrue("'invalid' is not one of ['memberOf', 'distinctInstance']" in str(e))
 
-
     @patch("cloudlift.config.service_configuration.get_resource_for")
     def test_set_config_system_controls(self, mock_get_resource_for):
         mock_get_resource_for.return_value = MagicMock()
@@ -230,3 +233,28 @@ class TestServiceConfigurationValidation(TestCase):
             self.fail('Validation error expected but validation passed')
         except UnrecoverableException as e:
             self.assertTrue("'invalid' is not of type 'array'" in str(e))
+
+    @patch("cloudlift.config.service_configuration.get_resource_for")
+    def test_set_config_http_interface(self, mock_get_resource_for):
+        mock_get_resource_for.return_value = MagicMock()
+
+        service = ServiceConfiguration('test-service', 'test')
+
+        try:
+            service._validate_changes({
+                'cloudlift_version': 'test',
+                'services': {
+                    'TestService': {
+                        'memory_reservation': 1000,
+                        'command': None,
+                        'http_interface': {
+                            'internal': True,
+                            'container_port': 8080,
+                            'restrict_access_to': ['0.0.0.0/0'],
+                            'alb_enabled': True
+                        }
+                    }
+                }
+            })
+        except UnrecoverableException as e:
+            self.fail('Exception thrown: {}'.format(e))

--- a/test/config/test_region.py
+++ b/test/config/test_region.py
@@ -1,0 +1,54 @@
+from cloudlift.config import region
+from unittest import TestCase
+from mock import patch, MagicMock
+
+
+class TestRegion(TestCase):
+    @patch("cloudlift.config.region.EnvironmentConfiguration")
+    def test_get_region_for_environment_without_cache(self, env_config):
+        mock = MagicMock()
+        env_config.return_value = mock
+        mock.get_config.return_value = {
+            'test-env': {
+                'region': 'mock-region'
+            }
+        }
+
+        expected = 'mock-region'
+        actual = region.get_region_for_environment('test-env')
+
+        self.assertEqual(actual, expected)
+
+    @patch("cloudlift.config.region.local_cache", {'region': 'mock-region'})
+    @patch("cloudlift.config.region.EnvironmentConfiguration")
+    def test_get_region_for_environment_with_cache(self, env_config):
+        expected = 'mock-region'
+        actual = region.get_region_for_environment('test-env')
+
+        self.assertEqual(actual, expected)
+        env_config.assert_not_called()
+
+    @patch("cloudlift.config.region.EnvironmentConfiguration")
+    def test_get_service_templates_bucket_for_environment_without_cache(self, env_config):
+        mock = MagicMock()
+        env_config.return_value = mock
+        mock.get_config.return_value = {
+            'test-env': {
+                'service_templates_bucket': 'mock.bucket.url'
+            }
+        }
+
+        expected = 'mock.bucket.url'
+        actual = region.get_service_templates_bucket_for_environment('test-env')
+
+        self.assertEqual(actual, expected)
+
+    @patch("cloudlift.config.region.local_cache", {'bucket': 'mock.bucket.url'})
+    @patch("cloudlift.config.region.EnvironmentConfiguration")
+    def test_get_service_templates_bucket_for_environment_with_cache(self, env_config):
+        expected = 'mock.bucket.url'
+
+        actual = region.get_service_templates_bucket_for_environment('test-env')
+
+        self.assertEqual(actual, expected)
+        env_config.assert_not_called()

--- a/test/deployment/test_cloud_formation_stack.py
+++ b/test/deployment/test_cloud_formation_stack.py
@@ -1,0 +1,58 @@
+from cloudlift.deployment.cloud_formation_stack import prepare_stack_options_for_template
+
+from unittest import TestCase
+from mock import patch
+from moto import mock_s3
+import boto3
+from tempfile import NamedTemporaryFile
+
+
+class TestCloudFormationStack(TestCase):
+    def test_prepare_stack_options_for_template_for_small_template(self):
+        template_body = 'sample template'
+        environment = 'dummy-test'
+        stack_name = 'test-stack'
+
+        expected_options = {
+            'TemplateBody': template_body
+        }
+        options = prepare_stack_options_for_template(template_body, environment, stack_name)
+
+        self.assertEqual(options, expected_options)
+
+    @patch("cloudlift.deployment.cloud_formation_stack.get_service_templates_bucket_for_environment")
+    @patch("cloudlift.config.region.get_region_for_environment")
+    @patch("cloudlift.deployment.cloud_formation_stack.get_region_for_environment")
+    def test_prepare_stack_options_for_template_for_large_template(self,
+                                                                   local_get_region_for_environment,
+                                                                   config_get_region_for_environment,
+                                                                   get_service_templates_bucket_for_environment):
+        mock_bucket_url = "mock.bucket.url"
+        mock_region = "mock-region"
+
+        local_get_region_for_environment.return_value = mock_region
+        config_get_region_for_environment.return_value = mock_region
+        get_service_templates_bucket_for_environment.return_value = mock_bucket_url
+
+        with mock_s3():
+            template_body = 'sample template' * 4000
+            environment = 'dummy-test'
+            stack_name = 'test-stack'
+
+            expected_options = {
+                'TemplateURL': 'https://s3-mock-region.amazonaws.com/mock.bucket.url/dummy-test/test-stack.template'
+            }
+            options = prepare_stack_options_for_template(template_body, environment, stack_name)
+            self.assertEqual(options, expected_options)
+            s3 = boto3.resource('s3')
+
+            mock_bucket = s3.Bucket(mock_bucket_url)
+            self.assertEqual(mock_bucket.name, mock_bucket_url)
+
+            f = NamedTemporaryFile(delete=True)
+            mock_bucket.download_file('dummy-test/test-stack.template', f.name)
+
+            with open(f.name) as data:
+                self.assertEqual(data.read(), template_body)
+
+            f.close()


### PR DESCRIPTION
- Flag called `alb_enabled` to control if ALB should be provisioned
- If size of cloud formation template is greater than a threshold, upload to s3 and provide TemplateURL for creation/updation of stack.
- Fetch the s3 bucket details from environment configuration
- Cache region and buckets information in-memory to avoid repeated calls to dynamoDB
- Added tests