### PR TITLE
Add ability to specify container health check

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,29 @@ only within the VPC
 limit, i.e. at least this much memory will be available, and upto whatever
 memory is free in running container instance. Minimum: 10 MB, Maximum: 8000 MB
 
+`container_health_check` can be used to specify docker container health and maps to `healthCheck`
+in ECS container definition. For more information, check [here](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_HealthCheck.html)
+
+An example service using `container_health_check`
+
+```json
+{
+  "services": {
+    "Test123": {
+      "command": null,
+      "container_health_check": {
+        "command": "curl http://localhost/health",
+        "start_delay": 30,
+        "retries": 10,
+        "interval": 10,
+        "timeout": 5
+      },
+      "memory_reservation": 100
+    }
+  }
+}
+```
+
 #### 3. Deploy service
 
 This command build the image (only if the version is unavailable in ECR), pushes to ECR and updates the ECS 

--- a/cloudlift/config/service_configuration.py
+++ b/cloudlift/config/service_configuration.py
@@ -210,9 +210,24 @@ class ServiceConfiguration(object):
                         "command": {
                             "type": "string"
                         },
-                        "initial_delay": {
+                        "start_period": {
                             "type": "number"
-                        }
+                        },
+                        "retries": {
+                            "type": "number",
+                            "minimum": 1,
+                            "maximum": 10
+                        },
+                        "interval": {
+                            "type": "number",
+                            "minimum": 5,
+                            "maximum": 300
+                        },
+                        "timeout": {
+                            "type": "number",
+                            "minimum": 2,
+                            "maximum": 60
+                        },
                     },
                     "required": ["command"]
                 },

--- a/cloudlift/config/service_configuration.py
+++ b/cloudlift/config/service_configuration.py
@@ -204,6 +204,18 @@ class ServiceConfiguration(object):
                 "stop_timeout": {
                     "type": "number"
                 },
+                "container_health_check": {
+                    "type": "object",
+                    "properties": {
+                        "command": {
+                            "type": "string"
+                        },
+                        "initial_delay": {
+                            "type": "number"
+                        }
+                    },
+                    "required": ["command"]
+                },
                 "placement_constraints": {
                     "type": "array",
                     "items": {

--- a/cloudlift/deployment/service_template_generator.py
+++ b/cloudlift/deployment/service_template_generator.py
@@ -193,8 +193,14 @@ service is down',
         if 'container_health_check' in config:
             configured_health_check = config['container_health_check']
             ecs_health_check =  {'Command': ['CMD-SHELL', configured_health_check['command']]}
-            if configured_health_check['initial_delay'] > 0:
-                ecs_health_check['StartPeriod'] = int(configured_health_check['initial_delay'])
+            if 'start_period' in configured_health_check:
+                ecs_health_check['StartPeriod'] = int(configured_health_check['start_period'])
+            if 'retries' in configured_health_check:
+                ecs_health_check['Retries'] = int(configured_health_check['retries'])
+            if 'interval' in configured_health_check:
+                ecs_health_check['Interval'] = int(configured_health_check['interval'])
+            if 'timeout' in configured_health_check:
+                ecs_health_check['Timeout'] = int(configured_health_check['timeout'])
             container_definition_arguments['HealthCheck'] = HealthCheck(
                 **ecs_health_check
             )

--- a/cloudlift/deployment/service_template_generator.py
+++ b/cloudlift/deployment/service_template_generator.py
@@ -13,7 +13,8 @@ from troposphere.ecs import (AwsvpcConfiguration, ContainerDefinition,
                              DeploymentConfiguration, Environment,
                              LoadBalancer, LogConfiguration,
                              NetworkConfiguration, PlacementStrategy,
-                             PortMapping, Service, TaskDefinition, PlacementConstraint, SystemControl)
+                             PortMapping, Service, TaskDefinition, PlacementConstraint, SystemControl,
+                             HealthCheck)
 from troposphere.elasticloadbalancingv2 import Action, Certificate, Listener
 from troposphere.elasticloadbalancingv2 import LoadBalancer as ALBLoadBalancer
 from troposphere.elasticloadbalancingv2 import (Matcher, RedirectConfig,
@@ -188,6 +189,15 @@ service is down',
 
         if config['command'] is not None:
             container_definition_arguments['Command'] = [config['command']]
+
+        if 'container_health_check' in config:
+            configured_health_check = config['container_health_check']
+            ecs_health_check =  {'Command': ['CMD-SHELL', configured_health_check['command']]}
+            if configured_health_check['initial_delay'] > 0:
+                ecs_health_check['StartPeriod'] = int(configured_health_check['initial_delay'])
+            container_definition_arguments['HealthCheck'] = HealthCheck(
+                **ecs_health_check
+            )
 
         cd = ContainerDefinition(**container_definition_arguments)
 

--- a/cloudlift/version/__init__.py
+++ b/cloudlift/version/__init__.py
@@ -1,2 +1,1 @@
-VERSION = '1.7.1'
-
+VERSION = '1.7.2'

--- a/test/config/service_configuration_test.py
+++ b/test/config/service_configuration_test.py
@@ -258,3 +258,55 @@ class TestServiceConfigurationValidation(TestCase):
             })
         except UnrecoverableException as e:
             self.fail('Exception thrown: {}'.format(e))
+
+    @patch("cloudlift.config.service_configuration.get_resource_for")
+    def test_set_config_health_check_command(self, mock_get_resource_for):
+        mock_get_resource_for.return_value = MagicMock()
+
+        service = ServiceConfiguration('test-service', 'test')
+
+        try:
+            service._validate_changes({
+                'cloudlift_version': 'test',
+                'services': {
+                    'TestService': {
+                        'memory_reservation': 1000,
+                        'command': None,
+                        'http_interface': {
+                            'internal': True,
+                            'container_port': 8080,
+                            'restrict_access_to': ['0.0.0.0/0'],
+                            'alb_enabled': True,
+                        },
+                        "container_health_check": {
+                            "command": "echo 'Working'",
+                            "initial_delay": 30,
+                        }
+                    }
+                }
+            })
+        except UnrecoverableException as e:
+            self.fail('Exception thrown: {}'.format(e))
+
+        try:
+            service._validate_changes({
+                'cloudlift_version': 'test',
+                'services': {
+                    'TestService': {
+                        'memory_reservation': 1000,
+                        'command': None,
+                        'http_interface': {
+                            'internal': True,
+                            'container_port': 8080,
+                            'restrict_access_to': ['0.0.0.0/0'],
+                            'alb_enabled': True,
+                        },
+                        "container_health_check": {
+                            "initial_delay": 123,
+                        }
+                    }
+                }
+            })
+            self.fail('Exception expected but did not fail')
+        except UnrecoverableException as e:
+            self.assertTrue(True)

--- a/test/config/service_configuration_test.py
+++ b/test/config/service_configuration_test.py
@@ -280,7 +280,10 @@ class TestServiceConfigurationValidation(TestCase):
                         },
                         "container_health_check": {
                             "command": "echo 'Working'",
-                            "initial_delay": 30,
+                            "start_period": 30,
+                            "retries": 4,
+                            "interval": 5,
+                            "timeout": 30,
                         }
                     }
                 }
@@ -302,7 +305,7 @@ class TestServiceConfigurationValidation(TestCase):
                             'alb_enabled': True,
                         },
                         "container_health_check": {
-                            "initial_delay": 123,
+                            "start_period": 123,
                         }
                     }
                 }


### PR DESCRIPTION
- Add ability to specify container level checks
- The following is the specification

```JSON
"container_health_check": {
     "command": "echo 'Working'",
     "start_delay": 30,
     "retries": 10,
     "interval": 10,
     "timeout": 5
}
```