### PR TITLE
[INFRA-891][IN PROGRESS] Update Jenkinsfile to use dockerhub instead of ECR

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -31,11 +31,14 @@ pipeline {
         }
         
         stage('Push to ECR') {
+	    environment {
+                DOCKERHUB_LOGIN = credentials('dockerhub-login')
+    	    }
             steps {
                 sh '''
-                    aws ecr get-login-password --region ${AWS_DEFAULT_REGION} | docker login --username AWS --password-stdin ${AWS_RIPPLING_ACCOUNT}
-                    docker tag cloudlift:${TAG} ${AWS_RIPPLING_ACCOUNT}/cloudlift-repo:${TAG}
-                    docker push ${AWS_RIPPLING_ACCOUNT}/cloudlift-repo:${TAG}
+                    docker login -u ${DOCKERHUB_LOGIN_USR} -p ${DOCKERHUB_LOGIN_PSW}
+                    docker tag cloudlift:${TAG} rippling/cloudlift:${TAG}
+                    docker push rippling/cloudlift:${TAG}
                 '''
             }
         }


### PR DESCRIPTION
## Purpose

To push Cloudlift image to public dockerhub

## Summary of changes

Jenkinsfile references Dockerhub credentials and pushes to dockerhub public.

## PR Checklist:

- [x] [JIRA Ticket](https://rippling.atlassian.net/browse/INFRA-881)
- [x] Self-review
- [x] Comments added where necessary
- [ ] [Documentation](https://rippling.atlassian.net/wiki/spaces/ENG/overview) updated
- [x] Tested manually

Please refer to Rippling's [Code Styleguide](https://rippling.atlassian.net/wiki/spaces/ENG/pages/141656065/Code+Styleguide) and [Code Modularity](https://rippling.atlassian.net/wiki/spaces/ENG/pages/709197839/Code+Modularity) documentation.
