### PR TITLE
Avoid passing EcsClient to multiprocessing

### DIFF
--- a/cloudlift/deployment/deployer.py
+++ b/cloudlift/deployment/deployer.py
@@ -5,13 +5,17 @@ from pprint import pformat
 from time import sleep, time
 
 import boto3
-from cloudlift.config import ParameterStore, secrets_manager
-from cloudlift.config.logging import (log, log_bold, log_err, log_intent,
-                                      log_warning, log_with_color)
-from cloudlift.deployment.ecs import DeployAction, EcsClient, EcsTaskDefinition
+from deepdiff import DeepDiff
+
+from cloudlift.config import ParameterStore
+from cloudlift.config import secrets_manager
+from cloudlift.config.logging import log_bold, log_err, log_intent, log_with_color, log_warning, log
+from cloudlift.deployment.ecs import DeployAction
+from cloudlift.deployment.ecs import EcsClient
+from cloudlift.deployment.ecs import EcsTaskDefinition
 from cloudlift.deployment.task_definition_builder import TaskDefinitionBuilder
 from cloudlift.exceptions import UnrecoverableException
-from deepdiff import DeepDiff
+
 
 
 def find_essential_container(container_definitions):

--- a/cloudlift/deployment/service_updater.py
+++ b/cloudlift/deployment/service_updater.py
@@ -3,14 +3,14 @@ import os
 from time import sleep
 
 import boto3
-from cloudlift.config import (ServiceConfiguration, get_account_id,
-                              get_cluster_name, get_region_for_environment)
+
+from cloudlift.config import get_account_id, get_cluster_name, \
+    ServiceConfiguration, get_region_for_environment
 from cloudlift.config.logging import log_bold, log_intent, log_warning
-from cloudlift.deployment import ServiceInformationFetcher, deployer
-from cloudlift.deployment.ecr import ECR
-from cloudlift.deployment.ecs import EcsClient
+from cloudlift.deployment import deployer, ServiceInformationFetcher
 from cloudlift.exceptions import UnrecoverableException
 from cloudlift.utils import chunks
+from cloudlift.deployment.ecr import ECR
 from stringcase import spinalcase
 
 DEPLOYMENT_COLORS = ['blue', 'magenta', 'white', 'cyan']


### PR DESCRIPTION
Fixes https://github.com/GetSimpl/cloudlift/issues/51

`botocore` client should not be pickled - this is done internally when passing EcsClient to `multiprocessing`.

Currently, python version > 3.7 breaks cloudlift deployment. Tested on MacOS 11.2.1 & Python 3.7.4